### PR TITLE
fix(tokens): update to use tokens differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,27 @@ This action publishes a gitbook to github pages.
 The source branch is `master`, and the target branch is `gh-pages`. If `gh-pages` does not exist, it will be created automatically.
 
 ## How to Use
+
 ```yml
-uses: tuliren/publish-gitbook@v1
-with:
-  github_token: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  build:
+    name: Build Gitbook
+    runs-on: ubuntu-latest
+    steps:
+      # We must check out the repo first
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Now run this publish action
+      - name: Publish
+        uses: tuliren/publish-gitbook@v0.9.1
+        with:
+          personal_token: ${{ secrets.PERSONAL_TOKEN }}
 ```
 
 ## Gotcha
-Unfortunately auto `GITHUB_TOKEN` in workflows cannot trigger a GitHub Pages build. So this action is currently useless. More details can be found here:
+
+Unfortunately auto `GITHUB_TOKEN` in workflows cannot trigger a GitHub Pages build. So the current workaround is to generate a new Personal Access Token and supply it separately as `personal_token`.
+
+More details can be found here:
 - [Github action not triggering gh-pages upon push](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869)
 - [Cannot deploy with GITHUB_TOKEN for new repository](https://github.com/peaceiris/actions-gh-pages/issues/9)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,29 @@
 #!/bin/sh -l
 
+print_info(){
+  echo "\033[32mINFO \033[0m $@" > /dev/stderr
+}
+
+print_error(){
+  echo "\033[31mERROR\033[0m \a $@" > /dev/stderr
+}
+
+PUBLISHER_REPO=""
+# setup publisher
+if [ -n "${INPUT_PERSONAL_TOKEN}" ]; then
+    print_info "using provided PERSONAL_TOKEN"
+    PUBLISHER_REPO="https://x-access-token:${INPUT_PERSONAL_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+elif [ -n "${GITHUB_TOKEN}" ]; then
+    print_info "using automatic GITHUB_TOKEN"
+    PUBLISHER_REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+else
+    print_error "no PERSONAL_TOKEN or GITHUB_TOKEN found, you can provide one in your workflow YAML"
+    exit 1
+fi
+
 # config git
 git config --local user.name "${GITHUB_ACTOR}"
 git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-
-# check github token
-[ -z "${INPUT_GITHUB_TOKEN}" ] && {
-  echo 'Missing input "github_token: ${{ secrets.GITHUB_TOKEN }}".';
-  exit 1;
-};
 
 # checkout gh-pages branch
 set +e
@@ -18,17 +33,22 @@ git status
 set -e
 
 # install gitbook
+print_info "installing gitbook-cli"
 npm install gitbook-cli  -g
-gitbook -v
+
+print_info "installing gitbook plugins"
+gitbook --version
 gitbook install
 
 # build gitbook
+print_info "buildling gitbook"
 gitbook build
 
 # copy the static site files into the current directory
 cp -R _book/* .
 
 # remove 'node_modules' and '_book' directory
+print_info "cleaning artifacts"
 git clean -fx node_modules
 git clean -fx _book
 
@@ -39,9 +59,8 @@ git add .
 COMMIT_MESSAGE="Update gitbook `date '+%Y-%m-%d %H:%M:%S'`"
 git commit -a -m "${COMMIT_MESSAGE}"
 
-# setup publisher
-PUBLISHER_REPO="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 git remote add publisher ${PUBLISHER_REPO}
 
 # push to the publisher
+print_info "pushing to gh-pages branch"
 git push -q -u publisher gh-pages


### PR DESCRIPTION
This will now support either the automatically available GITHUB_TOKEN (which may have publishing difficulties after pushing to `gh-pages`) or INPUT_PERSONAL_TOKEN provided in the workflow YAML file (the ideal way, with working publish).

Thanks for your work in putting this together!